### PR TITLE
Added another example filter in Kotlin

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This project is intended to assist a developer in learning what is needed to cre
  - `scp ./hello-world-groovy/src/main/resources/META-INF/schema/examples/hello-world-groovy.cfg.xml root@<SERVER_HOSTING_REPOSE>:/etc/repose/`
  - `scp ./hello-world-java/src/main/resources/META-INF/schema/examples/hello-world-java.cfg.xml     root@<SERVER_HOSTING_REPOSE>:/etc/repose/`
  - `scp ./hello-world-scala/src/main/resources/META-INF/schema/examples/hello-world-scala.cfg.xml   root@<SERVER_HOSTING_REPOSE>:/etc/repose/`
+ - `scp ./hello-world-kotlin/src/main/resources/META-INF/schema/examples/hello-world-kotlin.cfg.xml   root@<SERVER_HOSTING_REPOSE>:/etc/repose/`
 
 ## Add one or more of the hello-world filters to the system-model.cfg.xml
  - `ssh root@<SERVER_HOSTING_REPOSE>`
@@ -40,6 +41,7 @@ This project is intended to assist a developer in learning what is needed to cre
         <module>hello-world-java</module>
         <module>hello-world-scala</module>
         <module>hello-world-groovy</module>
+        <module>hello-world-kotlin</module>
         <module>hello-world-new</module>
     </modules>
     ...

--- a/custom-bundle/pom.xml
+++ b/custom-bundle/pom.xml
@@ -31,6 +31,11 @@
             <artifactId>hello-world-groovy</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.openrepose.filters.custom</groupId>
+            <artifactId>hello-world-kotlin</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/custom-bundle/src/main/application/WEB-INF/web-fragment.xml
+++ b/custom-bundle/src/main/application/WEB-INF/web-fragment.xml
@@ -13,4 +13,8 @@
         <filter-name>hello-world-groovy</filter-name>
         <filter-class>org.openrepose.filters.custom.helloworldgroovy.HelloWorldGroovyFilter</filter-class>
     </filter>
+    <filter>
+        <filter-name>hello-world-kotlin</filter-name>
+        <filter-class>org.openrepose.filters.custom.helloworldkotlin.HelloWorldKotlinFilter</filter-class>
+    </filter>
 </web-fragment>

--- a/hello-world-kotlin/pom.xml
+++ b/hello-world-kotlin/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.openrepose.filters.custom</groupId>
+        <artifactId>repose-hello-world</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <name>Repose Hello World - Kotlin</name>
+    <artifactId>hello-world-kotlin</artifactId>
+    <packaging>jar</packaging>
+
+    <description>
+        This filter is a custom Hello World filter written in Kotlin.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.openrepose</groupId>
+            <artifactId>core-lib</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.openrepose</groupId>
+            <artifactId>core-service-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.openrepose</groupId>
+            <artifactId>utilities</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jvnet.jaxb2_commons</groupId>
+            <artifactId>jaxb2-basics-runtime</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-test-junit</artifactId>
+            <version>${kotlin.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
+        <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
+        <plugins>
+            <!-- Kotlin -->
+            <plugin>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <version>${kotlin.version}</version>
+
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <goals> <goal>compile</goal> </goals>
+                    </execution>
+
+                    <execution>
+                        <id>test-compile</id>
+                        <goals> <goal>test-compile</goal> </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Cleans up the XSD to conform to XML 1.0 -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>xml-maven-plugin</artifactId>
+            </plugin>
+
+            <!-- JAXB Schema Compilation Support -->
+            <plugin>
+                <groupId>org.jvnet.jaxb2.maven2</groupId>
+                <artifactId>maven-jaxb2-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/hello-world-kotlin/src/main/kotlin/org/openrepose/filters/custom/helloworldkotlin/HelloWorldKotlinFilter.kt
+++ b/hello-world-kotlin/src/main/kotlin/org/openrepose/filters/custom/helloworldkotlin/HelloWorldKotlinFilter.kt
@@ -1,0 +1,87 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2016 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+package org.openrepose.filters.custom.helloworldkotlin
+
+import org.openrepose.commons.config.manager.UpdateListener
+import org.openrepose.commons.utils.servlet.http.MutableHttpServletRequest
+import org.openrepose.commons.utils.servlet.http.MutableHttpServletResponse
+import org.openrepose.core.filter.FilterConfigHelper
+import org.openrepose.core.services.config.ConfigurationService
+import org.openrepose.filters.custom.helloworldkotlin.config.HelloWorldKotlinConfig
+import org.slf4j.LoggerFactory
+import javax.inject.Inject
+import javax.inject.Named
+import javax.servlet.*
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+@Named
+class HelloWorldKotlinFilter @Inject constructor(configurationService: ConfigurationService) : Filter, UpdateListener<HelloWorldKotlinConfig> {
+
+    private final val LOG = LoggerFactory.getLogger(HelloWorldKotlinFilter::class.java)
+    private final val DEFAULT_CONFIG = "hello-world-kotlin.cfg.xml"
+
+    private val configurationService = configurationService
+    private var configurationFile = DEFAULT_CONFIG
+    private var messages = emptyList<String>()
+    private var initialized = false
+
+    override fun init(filterConfig: FilterConfig?) {
+        configurationFile = FilterConfigHelper(filterConfig).getFilterConfig(DEFAULT_CONFIG)
+        LOG.info("Initializing filter using config $configurationFile")
+        val xsdURL = javaClass.getResource("/META-INF/schema/config/hello-world-kotlin.xsd")
+        configurationService.subscribeTo(
+                filterConfig!!.filterName,
+                configurationFile,
+                xsdURL,
+                this,
+                HelloWorldKotlinConfig::class.java)
+    }
+
+    override fun doFilter(request: ServletRequest, response: ServletResponse, filterChain: FilterChain) {
+        if (!isInitialized) {
+            LOG.error("Hello World Kotlin filter has not yet initialized...")
+            (response as HttpServletResponse).sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR)
+        } else {
+            val mutableHttpRequest = MutableHttpServletRequest.wrap(request as HttpServletRequest)
+            val mutableHttpResponse = MutableHttpServletResponse.wrap(mutableHttpRequest, response as HttpServletResponse)
+
+            LOG.trace("Hello World Kotlin filter processing request...")
+            messages.forEach { LOG.info("Request message: $it") }
+
+            LOG.trace("Hello World Kotlin filter passing on down the Filter Chain...")
+            filterChain.doFilter(mutableHttpRequest, mutableHttpResponse)
+
+            LOG.trace("Hello World Kotlin filter processing response...")
+            messages.forEach { LOG.info("Response message: $it") }
+        }
+    }
+
+    override fun destroy() {
+        configurationService.unsubscribeFrom(configurationFile, this)
+    }
+
+    override fun configurationUpdated(config: HelloWorldKotlinConfig) {
+        messages = config.messages.message.map { it.value }
+        initialized = true
+    }
+
+    override fun isInitialized(): Boolean = initialized
+}

--- a/hello-world-kotlin/src/main/resources/META-INF/schema/config/bindings.xjb
+++ b/hello-world-kotlin/src/main/resources/META-INF/schema/config/bindings.xjb
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<bindings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://java.sun.com/xml/ns/jaxb"
+          version="2.0"
+          xsi:schemaLocation="http://java.sun.com/xml/ns/jaxb http://java.sun.com/xml/ns/jaxb/bindingschema_2_0.xsd"
+          schemaLocation="hello-world-kotlin.xsd">
+    <schemaBindings>
+        <package name="org.openrepose.filters.custom.helloworldkotlin.config"/>
+    </schemaBindings>
+</bindings>

--- a/hello-world-kotlin/src/main/resources/META-INF/schema/config/hello-world-kotlin.xsd
+++ b/hello-world-kotlin/src/main/resources/META-INF/schema/config/hello-world-kotlin.xsd
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xs:schema elementFormDefault="qualified" attributeFormDefault="unqualified"
+           targetNamespace="http://docs.example.com/repose/hello-world-kotlin/v1.0"
+           xmlns:hello-world-kotlin="http://docs.example.com/repose/hello-world-kotlin/v1.0"
+           xmlns:html="http://www.w3.org/1999/xhtml"
+           xmlns:xerces="http://xerces.apache.org"
+           xmlns:saxon="http://saxon.sf.net/"
+           xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+    <!-- This matches the root element tag in hello-world-kotlin.cfg.xml created in step 14. -->
+    <xs:element name="hello-world-kotlin" type="hello-world-kotlin:HelloWorldKotlinConfig"/>
+    <xs:complexType name="HelloWorldKotlinConfig">
+        <xs:annotation>
+            <xs:documentation>
+                <html:p>
+                    Hello World can be configured by editing the hello-world-kotlin.cfg.xml file.
+                    The user can specify the messages to print to the log.
+                </html:p>
+            </xs:documentation>
+        </xs:annotation>
+
+        <xs:all>
+            <!-- This matches the child tag <hello-world-kotlin> in hello-world-kotlin.cfg.xml. -->
+            <xs:element name="messages" type="hello-world-kotlin:MessageList" minOccurs="1" maxOccurs="1"/>
+            <!-- There must be one and only one <messages> tag in hello-world-kotlin.cfg.xml -->
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="MessageList">
+        <xs:annotation>
+            <xs:documentation>
+                <html:p>
+                    List messages.
+                </html:p>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <!-- This matches the child tag <messages> in hello-world-kotlin.cfg.xml. -->
+            <!-- There is one or more instance of a <message> tag in hello-world-kotlin.cfg.xml -->
+            <xs:element name="message" type="hello-world-kotlin:Message"
+                        minOccurs="1" maxOccurs="unbounded"/>
+        </xs:sequence>
+
+        <!-- Must match <message> tag (children of messages tag in hello-world-kotlin.cfg.xml). -->
+        <xs:assert vc:minVersion="1.1"
+                   test="count(distinct-values(hello-world-kotlin:message /@value)) = count(hello-world-kotlin:message /@value)"
+                   xerces:message="A message must have value unique within their containing messages list"
+                   saxon:message="A message must have value unique within their containing messages list"/>
+    </xs:complexType>
+
+    <!-- This results in the generation of
+    target/generated-sources/xjc/org/openrepose/filters/custom/helloworldkotlin/config/Message.java
+    with a property named value with type: String -->
+    <xs:complexType name="Message">
+        <xs:annotation>
+            <xs:documentation>
+                <html:p>
+                    The message
+                </html:p>
+            </xs:documentation>
+        </xs:annotation>
+
+        <!-- There is only one attribute of the <message> tag, and it is required. -->
+        <xs:attribute name="value" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    <html:p>
+                        This is the value that is printed to the log.
+                    </html:p>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+</xs:schema>

--- a/hello-world-kotlin/src/main/resources/META-INF/schema/examples/hello-world-kotlin.cfg.xml
+++ b/hello-world-kotlin/src/main/resources/META-INF/schema/examples/hello-world-kotlin.cfg.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<hello-world-kotlin xmlns='http://docs.example.com/repose/hello-world-kotlin/v1.0'>
+    <messages>
+        <!-- This is the message you want to output to the log. -->
+        <message value="My Hello World in Kotlin!!!" />
+        <message value="Another message in the Kotlin filter." />
+    </messages>
+</hello-world-kotlin>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
         <scala.version>2.10.3</scala.version>
         <scala.dep.version>2.10</scala.dep.version>
         <groovy.version>2.1.3</groovy.version>
+        <kotlin.version>1.0.0</kotlin.version>
         <gmaven.version>1.5</gmaven.version>
         <log4j.version>2.3</log4j.version>
         <junit.version>4.10</junit.version>
@@ -47,6 +48,7 @@
         <module>hello-world-java</module>
         <module>hello-world-scala</module>
         <module>hello-world-groovy</module>
+        <module>hello-world-kotlin</module>
     </modules>
 
     <repositories>


### PR DESCRIPTION
I created a new example filter in Kotlin using the steps in the README.  The Kotlin module builds normally using Maven, and I confirmed that the module JAR contains the built classes (including the classes for the generated source).

To test, I deployed a local instance of Repose, installed the custom bundle EAR I built, copied the example Kotlin filter config, and configured the new "hello-world-kotlin" filter in the System Model.  Repose started up without issue, and I confirmed the expected configured messages were logged when a request was sent.